### PR TITLE
Small change to make svdlibc work with larger matrices on highmem machines

### DIFF
--- a/svdlib.c
+++ b/svdlib.c
@@ -17,7 +17,7 @@ void svdResetCounters(void) {
 
 /* Row major order.  Rows are vectors that are consecutive in memory.  Matrix
    is initialized to empty. */
-DMat svdNewDMat(int rows, int cols) {
+DMat svdNewDMat(long rows, long cols) {
   int i;
   DMat D = (DMat) malloc(sizeof(struct dmat));
   if (!D) {perror("svdNewDMat"); return NULL;}
@@ -42,7 +42,7 @@ void svdFreeDMat(DMat D) {
 }
 
 
-SMat svdNewSMat(int rows, int cols, int vals) {
+SMat svdNewSMat(long rows, long cols, long vals) {
   SMat S = (SMat) calloc(1, sizeof(struct smat));
   if (!S) {perror("svdNewSMat"); return NULL;}
   S->rows = rows;

--- a/svdlib.h
+++ b/svdlib.h
@@ -70,12 +70,12 @@ SVD_F_DB:  dense binary
 /******************************** Functions **********************************/
 
 /* Creates an empty dense matrix. */
-extern DMat svdNewDMat(int rows, int cols);
+extern DMat svdNewDMat(long rows, long cols);
 /* Frees a dense matrix. */
 extern void svdFreeDMat(DMat D);
 
 /* Creates an empty sparse matrix. */
-SMat svdNewSMat(int rows, int cols, int vals);
+SMat svdNewSMat(long rows, long cols, long vals);
 /* Frees a sparse matrix. */
 void svdFreeSMat(SMat S);
 


### PR DESCRIPTION
Make sure that we can allocate DMat or SMat if their size is larger than max integer provided we have enough memory. 

Without this change, memory allocation fails for Ut of size > 16G even if we have more than 16G of RAM.

Alternate fix would be to cast rows*cols to long inside the calloc call.
